### PR TITLE
added multi-command mp.events.addCommand-overload to definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -338,6 +338,7 @@ interface EventMpPool {
 	add(eventName: RageEnums.EventKey | string, callback: (...args: any[]) => void): void;
 	add(events: ({ [name: string]: (...args: any[]) => void; })): void;
 	addCommand(commandName: string, callback: (player: PlayerMp, fullText: string, ...args: string[]) => void): void;
+	addCommand(commands: { [commandName: string]: (player: PlayerMp, fullText: string, ...args: string[]) => void; }): void;
 	call(eventName: string, ...args: any[]): void;
 	getAllOf(eventName: string): EventMp[];
 	remove(eventName: string, handler?: (...args: any[]) => void): void;


### PR DESCRIPTION
The syntax for adding commands is not completely documented in the rage-mp wiki. Instead of
```typescript
mp.events.addCommand('a', (player: PlayerMp) => {
	mp.players.broadcast('a');
});
mp.events.addCommand('b', (player: PlayerMp) => {
	mp.players.broadcast('b');
});
```
one can also use
```typescript
mp.events.addCommand({
	'a':  (player: PlayerMp) => {
		mp.players.broadcast('a');
	},
	'b':  (player: PlayerMp) => {
		mp.players.broadcast('b');
	},
});
```
This patch adds the definition for that syntax.