### PR TITLE
Fixed wrong player.call typing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -146,7 +146,7 @@ interface PlayerMp extends EntityMp {
 	readonly voiceListeners: PlayerMp[];
 
 	ban(reason: string): void;
-	call(eventName: string, ...args: any[]): void;
+	call(eventName: string, args: any[]): void;
 	clearDecorations(): void;
 	disableVoiceTo(targetPlayer: PlayerMp): void;
 	enableVoiceTo(targetPlayer: PlayerMp): void;


### PR DESCRIPTION
https://wiki.rage.mp/index.php?title=Player::call
This function accepts only two arguments. The function is not variadic.