### PR TITLE
Added missed dimension in ColshapeMp methods

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -369,10 +369,10 @@ interface CheckpointMpPool extends EntityMpPool<CheckpointMp> {
 }
 
 interface ColshapeMpPool extends EntityMpPool<ColshapeMp> {
-	newCircle(x: number, y: number, range: number): ColshapeMp;
+	newCircle(x: number, y: number, range: number, dimension?: number): ColshapeMp;
 	newCuboid(x: number, y: number, z: number, width: number, depth: number, height: number): ColshapeMp;
 	newRectangle(x: number, y: number, width: number, height: number): ColshapeMp;
-	newSphere(x: number, y: number, z: number, range: number): ColshapeMp;
+	newSphere(x: number, y: number, z: number, range: number, dimension?: number): ColshapeMp;
 	newTube(x: number, y: number, z: number, range: number, height: number): ColshapeMp;
 }
 


### PR DESCRIPTION
The optional dimension argument was omitted in two methods.

https://wiki.rage.mp/index.php?title=Colshapes::newCircle
https://wiki.rage.mp/index.php?title=Colshapes::newSphere