### PR TITLE
Workaround dummy entity

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -83,13 +83,12 @@ interface ColshapeMp extends EntityMp {
 }
 
 interface DummyEntityMp {
-	dummyType: number;
-
 	// TODO (temporary solution):
 	// Since this is a very abstract concept, it is not at all a familiar essence, but it has most of its properties.
 	// The easiest option is, of course, to inherit the EntityMpPool interface, but this will add non-existent methods and parameters associated with the dimension and position.
 	// It is proposed in the future to introduce a more abstract concept than an entity, which will have only an ID, a type and several basic methods such as deletion, enumeration and transformation into an array. The same goes for the entity pool.
 
+	dummyType: number;
 	readonly id: number;
 	readonly type: RageEnums.EntityType;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -414,10 +414,13 @@ interface DummyEntityMpPool {
 	readonly length: number;
 	readonly size: number;
 
+	apply(fn: (...args: any[]) => void, ...args: any[]): void;
 	at(index: number): DummyEntityMp;
 	exists(entity: DummyEntityMp | number): boolean;
 	forEach(fn: (entity: DummyEntityMp) => void): void;
 	forEachByType(dummyEntityType: number, fn: (entity: DummyEntityMp) => void): void;
+	toArray(): DummyEntityMp[];
+	toArrayFast(): DummyEntityMp[];
 }
 
 interface EntityMpPool<TEntity> {

--- a/index.d.ts
+++ b/index.d.ts
@@ -85,10 +85,12 @@ interface ColshapeMp extends EntityMp {
 interface DummyEntityMp {
 	// TODO (temporary solution):
 	// Since this is a very abstract concept, it is not at all a familiar essence, but it has most of its properties.
-	// The easiest option is, of course, to inherit the EntityMpPool interface, but this will add non-existent methods and parameters associated with the dimension and position.
-	// It is proposed in the future to introduce a more abstract concept than an entity, which will have only an ID, a type and several basic methods such as deletion, enumeration and transformation into an array. The same goes for the entity pool.
+	// The easiest option is, of course, to inherit the EntityMpPool interface, but this will add
+	// non-existent methods and parameters associated with the dimension and position.
+	// It is proposed in the future to introduce a more abstract concept than an entity, which will have only an ID, a type and several basic
+	// methods such as deletion, enumeration and transformation into an array. The same goes for the entity pool.
 
-	dummyType: number; // btw editable and synced with clients.
+	dummyType: number; // Btw editable and synced with clients.
 	readonly id: number;
 	readonly type: RageEnums.EntityType;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -84,6 +84,19 @@ interface ColshapeMp extends EntityMp {
 
 interface DummyEntityMp {
 	dummyType: number;
+
+	// TODO (temporary solution):
+	// Since this is a very abstract concept, it is not at all a familiar essence, but it has most of its properties.
+	// The easiest option is, of course, to inherit the EntityMpPool interface, but this will add non-existent methods and parameters associated with the dimension and position.
+	// It is proposed in the future to introduce a more abstract concept than an entity, which will have only an ID, a type and several basic methods such as deletion, enumeration and transformation into an array. The same goes for the entity pool.
+
+	readonly id: number;
+	readonly type: RageEnums.EntityType;
+
+	getVariable(name: string): any | undefined;
+	destroy(): void;
+	setVariable(name: string, value: any): void;
+	setVariables(values: KeyValueCollection): void;
 }
 
 interface EntityMp {
@@ -395,6 +408,14 @@ interface ColshapeMpPool extends EntityMpPool<ColshapeMp> {
 interface DummyEntityMpPool {
 	"new"(dummyEntityType: number, sharedVariables: KeyValueCollection): DummyEntityMp;
 
+	// TODO (temporary solution, see interface DummyEntityMp).
+
+	readonly length: number;
+	readonly size: number;
+
+	at(index: number): DummyEntityMp;
+	exists(entity: DummyEntityMp | number): boolean;
+	forEach(fn: (entity: DummyEntityMp) => void): void;
 	forEachByType(dummyEntityType: number, fn: (entity: DummyEntityMp) => void): void;
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -88,7 +88,7 @@ interface DummyEntityMp {
 	// The easiest option is, of course, to inherit the EntityMpPool interface, but this will add non-existent methods and parameters associated with the dimension and position.
 	// It is proposed in the future to introduce a more abstract concept than an entity, which will have only an ID, a type and several basic methods such as deletion, enumeration and transformation into an array. The same goes for the entity pool.
 
-	dummyType: number;
+	dummyType: number; // btw editable and synced with clients.
 	readonly id: number;
 	readonly type: RageEnums.EntityType;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -418,7 +418,7 @@ interface DummyEntityMpPool {
 	at(index: number): DummyEntityMp;
 	exists(entity: DummyEntityMp | number): boolean;
 	forEach(fn: (entity: DummyEntityMp) => void): void;
-	forEachByType(dummyEntityType: number, fn: (entity: DummyEntityMp) => void): void;
+	forEachByType(dummyType: number, fn: (entity: DummyEntityMp) => void): void;
 	toArray(): DummyEntityMp[];
 	toArrayFast(): DummyEntityMp[];
 }


### PR DESCRIPTION
### Motivation

In 1.1, an extremely abstract dummy entity was introduced, and a rather acute problem appeared in server and client types, since this new type is difficult to inherit from a regular entity. She has no position and she exists outside of dimensions.

### Sentence

It takes a lot more time to introduce something even more abstract than just an entity. Something like a basic entity that has just an ID, a type, and several basic methods like deleting, setting and getting variables.

### Decision

I propose a temporary solution, which I myself do not really like, but inheriting an entity will be an even stranger solution, since an infinite number of useless and non-working methods and properties appear. Since this entity is not documented at all, I had to spend time and check which specific methods and parameters can be transferred.

The client already had such solutions, for example https://github.com/CocaColaBear/types-ragemp-c/blob/5ce5ce81f34d67751d81903da2cc00fffbaec1ee/index.d.ts#L135

### Inspection results for DummyEntityMpPool

All methods related to position and measurement must be removed.

![изображение](https://user-images.githubusercontent.com/57041750/103438786-e1d2a700-4c47-11eb-9ded-eea9e6bc00a4.png)

### Inspection results for DummyEntityMp

Likewise, delete everything related to position and dimension, as well as the model and transparency.

![изображение](https://user-images.githubusercontent.com/57041750/103438792-0af33780-4c48-11eb-8790-ca01a619bada.png)

